### PR TITLE
Refine CI image usage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# Exclude docs and CI configuration to keep build context small
+*.md
+.gitlab-ci.yml
+AGENTS.md
+.git
+node_modules
+__pycache__
+.env
+*.local
+.vscode/
+.idea/
+
+*.log
+tmp/
+build/
+.output/
+docker-bake.hcl
+frontend/dist
+*.sarif
+junit.xml
+.cache/
+*.swp
+.DS_Store

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,327 @@
+# GitLab CI/CD pipeline for Django and Vue application
+---
+# Stages: build -> test -> deploy
+# Release MRs run the full pipeline including Terraform and image push
+
+workflow:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      when: always
+    - if: '$CI_PIPELINE_SOURCE == "push"'
+      when: always
+    - if: '$CI_PIPELINE_SOURCE == "tag"'
+      when: always
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      when: always
+    - when: never
+
+# Docker-out-of-Docker runner with BuildKit enabled
+default:
+  # Custom CI image built from Dockerfile. Set `MY_CI_IMAGE` in CI variables.
+  image: $MY_CI_IMAGE
+  services:
+    - name: docker:dind
+      alias: docker
+  tags: ["runner17"]
+  variables:
+    DOCKER_HOST: unix:///var/run/docker.sock
+    DOCKER_TLS_CERTDIR: ""
+    DOCKER_BUILDKIT: "1"
+    TFSEC_VERSION: "1.28.1"
+  before_script: []
+  privileged: true
+  cache:
+    key: "$CI_PROJECT_ID-$CI_COMMIT_REF_SLUG-$CI_JOB_NAME"
+    policy: pull-push
+    paths:
+      - .cache/pip
+      - .npm
+
+.docker_setup: &docker_setup
+  before_script:
+    - docker info
+    - echo "$CI_REGISTRY_PASSWORD" | docker login -u "$CI_REGISTRY_USER" --password-stdin "$CI_REGISTRY"
+
+.sast_template: &sast_template
+  stage: test
+  extends: .docker_setup
+  rules:
+    - if: '$CI_COMMIT_REF_NAME =~ /^(feature|develop|release)(\/.*)?$/ || $CI_COMMIT_TAG'
+  needs:
+    - build_images
+  artifacts:
+    expire_in: 1 week
+
+stages:
+  - build
+  - test
+  - deploy
+
+# ---- Build stage ----
+
+# Build base images for all stages
+# NOTE: Images are built separately for clarity. They could be consolidated
+# using `docker buildx bake` for further optimization.
+build_images:
+  stage: build
+  extends: .docker_setup
+  script:
+    - |
+      BUILDER=builder-${CI_PIPELINE_ID}
+      docker buildx inspect $BUILDER >/dev/null 2>&1 || \
+        docker buildx create --name $BUILDER --use
+    - |
+      ARCH=$(uname -m)
+      case "$ARCH" in
+        aarch64) TFSEC_BIN=tfsec-linux-arm64 ;;
+        armv7l) TFSEC_BIN=tfsec-linux-armv7 ;;
+        *) TFSEC_BIN=tfsec-linux-amd64 ;;
+      esac
+      TFSEC_SHA256=$(curl -sSL https://github.com/aquasecurity/tfsec/releases/download/v${TFSEC_VERSION}/checksums.txt | grep ${TFSEC_BIN} | awk '{print $1}')
+    - |
+      docker buildx bake -f docker-bake.hcl all \
+        --set *.args.TARGET_ENV=${CI_COMMIT_REF_NAME} \
+        --set build.tags=$CI_REGISTRY_IMAGE/myapp-build:${CI_COMMIT_SHA},$CI_REGISTRY_IMAGE/myapp-build:latest \
+        --set sast-node.tags=$CI_REGISTRY_IMAGE/myapp-sast-node:${CI_COMMIT_SHA} \
+        --set sast-python.tags=$CI_REGISTRY_IMAGE/myapp-sast-python:${CI_COMMIT_SHA} \
+        --set sast-python.args.TFSEC_VERSION=${TFSEC_VERSION} \
+        --set sast-python.args.TFSEC_SHA256=${TFSEC_SHA256} \
+        --set test.tags=$CI_REGISTRY_IMAGE/myapp-test:${CI_COMMIT_SHA} \
+        --set test-runtime.tags=$CI_REGISTRY_IMAGE/myapp-test-runtime:${CI_COMMIT_SHA} \
+        --set runtime.tags=$CI_REGISTRY_IMAGE/myapp-runtime:${CI_COMMIT_SHA},$CI_REGISTRY_IMAGE/myapp-runtime:latest \
+        --push
+  after_script:
+    - docker buildx stop $BUILDER || true
+    - docker buildx rm $BUILDER || true
+  rules:
+    - if: '$CI_COMMIT_REF_NAME =~ /^feature\/.*$/ || $CI_COMMIT_REF_NAME =~ /^develop(\/.*)?$/ || $CI_COMMIT_REF_NAME =~ /^release(\/.*)?$/ || $CI_COMMIT_TAG'
+
+frontend_build:
+  stage: build
+  image: node:18-bullseye-slim
+  variables:
+    NODE_ENV: production
+  script:
+    - cd frontend
+    - npm ci
+    - npm run build
+  artifacts:
+    paths:
+      - frontend/dist
+    expire_in: 1 week
+  rules:
+    - if: '$CI_COMMIT_REF_NAME == "release"'
+
+# ---- Test stage ----
+volume_sast_unit:
+  stage: test
+  extends: .docker_setup
+  script:
+    - docker run --rm \
+        -v "$CI_PROJECT_DIR:/app" \
+        -w /app \
+        $CI_REGISTRY_IMAGE/myapp-test-runtime:${CI_COMMIT_SHA} \
+        sh -c 'ruff . --output-format sarif > ruff-volume.sarif && pytest --junitxml=unit-volume.xml tests/unit'
+  rules:
+    - if: '$CI_COMMIT_REF_NAME == "release"'
+  artifacts:
+    reports:
+      sast: ruff-volume.sarif
+      junit: unit-volume.xml
+    expire_in: 1 week
+  needs:
+    - build_images
+
+front_sast:
+  <<: *sast_template
+  script:
+    - docker run --rm $CI_REGISTRY_IMAGE/myapp-sast-node:${CI_COMMIT_SHA} sh -c 'cd /app/frontend 2>/dev/null || cd /app && eslint . -f sarif -o eslint.sarif'
+  artifacts:
+    reports:
+      sast: eslint.sarif
+    expire_in: 1 week
+
+backend_sast:
+  <<: *sast_template
+  script:
+    - docker run --rm $CI_REGISTRY_IMAGE/myapp-sast-python:${CI_COMMIT_SHA} sh -c 'ruff . --output-format sarif > ruff.sarif'
+  artifacts:
+    reports:
+      sast: ruff.sarif
+    expire_in: 1 week
+
+tf_sast:
+  <<: *sast_template
+  script:
+    - docker run --rm $CI_REGISTRY_IMAGE/myapp-sast-python:${CI_COMMIT_SHA} sh -c 'tfsec /app/terraform --format sarif > tfsec.sarif'
+  rules:
+    - if: '$CI_COMMIT_REF_NAME == "release" || $CI_COMMIT_TAG'
+  artifacts:
+    reports:
+      sast: tfsec.sarif
+    expire_in: 1 week
+
+unit_tests:
+  stage: test
+  extends: .docker_setup
+  script:
+    - docker run --rm \
+        -v "$CI_PROJECT_DIR:/app" \
+        -w /app \
+        $CI_REGISTRY_IMAGE/myapp-test:${CI_COMMIT_SHA} \
+        pytest --junitxml=junit.xml tests/unit
+  rules:
+    - if: '$CI_COMMIT_REF_NAME =~ /^develop(\/.*)?$/ || $CI_COMMIT_REF_NAME =~ /^release(\/.*)?$/ || $CI_COMMIT_TAG'
+  needs:
+    - build_images
+  artifacts:
+    reports:
+      junit: junit.xml
+    expire_in: 1 week
+
+shell_lint:
+  stage: test
+  image: koalaman/shellcheck-alpine
+  script:
+    - shellcheck entrypoint.sh
+  rules:
+    - if: '$CI_COMMIT_REF_NAME =~ /^feature\/.*$/ || $CI_COMMIT_REF_NAME =~ /^develop(\/.*)?$/ || $CI_COMMIT_REF_NAME =~ /^release(\/.*)?$/ || $CI_COMMIT_TAG'
+  needs: []
+
+functional_tests:
+  stage: test
+  extends: .docker_setup
+  script:
+    - NETWORK=ci_bridge_${CI_PIPELINE_ID}
+    - docker network create $NETWORK || true
+    - docker run -d \
+        --name django_app \
+        --network $NETWORK \
+        -v "$CI_PROJECT_DIR:/app" \
+        -w /app \
+        $CI_REGISTRY_IMAGE/myapp-test-runtime:${CI_COMMIT_SHA}
+    - docker exec django_app pytest tests/functional
+    - docker stop django_app
+  after_script:
+    - docker rm django_app || true
+    - docker network rm $NETWORK || true
+  rules:
+    - if: '$CI_COMMIT_REF_NAME == "release" || $CI_COMMIT_TAG'
+  needs:
+    - unit_tests
+
+# ---- Deploy stage ----
+terraform_init:
+  stage: deploy
+  image: hashicorp/terraform:1.5.6
+  tags: ["runner17", "terraform"]
+  script:
+    - terraform init
+  rules:
+    - if: '$CI_COMMIT_REF_NAME == "release"'
+      when: on_success
+    - if: '$CI_COMMIT_TAG && $CI_COMMIT_TAG =~ /^v/'
+      when: on_success
+  variables:
+    AWS_REGION: $AWS_REGION
+  # AWS credentials are supplied via protected variables
+  needs:
+    - functional_tests
+
+terraform_plan:
+  stage: deploy
+  image: hashicorp/terraform:1.5.6
+  tags: ["runner17", "terraform"]
+  script:
+    - terraform plan -out=tfplan
+  rules:
+    - if: '$CI_COMMIT_REF_NAME == "release"'
+      when: on_success
+    - if: '$CI_COMMIT_TAG && $CI_COMMIT_TAG =~ /^v/'
+      when: on_success
+  needs:
+    - terraform_init
+  when: on_success
+  variables:
+    AWS_REGION: $AWS_REGION
+  # AWS credentials are supplied via protected variables
+
+terraform_apply:
+  stage: deploy
+  image: hashicorp/terraform:1.5.6
+  tags: ["runner17", "terraform"]
+  script:
+    - terraform apply -auto-approve tfplan
+  rules:
+    - if: '$CI_COMMIT_REF_NAME == "release"'
+      when: on_success
+    - if: '$CI_COMMIT_TAG && $CI_COMMIT_TAG =~ /^v/'
+      when: on_success
+  needs:
+    - terraform_plan
+  when: on_success
+  variables:
+    AWS_REGION: $AWS_REGION
+  # AWS credentials are supplied via protected variables
+
+dev_deploy:
+  stage: deploy
+  extends: .docker_setup
+  script:
+    - docker pull $CI_REGISTRY_IMAGE/myapp-runtime:${CI_COMMIT_SHA}
+    - docker tag $CI_REGISTRY_IMAGE/myapp-runtime:${CI_COMMIT_SHA} myapp:dev-${CI_COMMIT_SHORT_SHA}
+    - echo "Deploying container to EC2 filesystem"
+  rules:
+    - if: '$CI_COMMIT_REF_NAME =~ /^develop(\/.*)?$/'
+  needs:
+    - functional_tests
+
+build_image:
+  stage: deploy
+  extends: .docker_setup
+  script:
+    - docker pull $CI_REGISTRY_IMAGE/myapp-runtime:${CI_COMMIT_SHA}
+    - |
+      DATE_TAG=$(date +%Y%m%d.%H%M)-${CI_COMMIT_SHORT_SHA}
+      docker tag $CI_REGISTRY_IMAGE/myapp-runtime:${CI_COMMIT_SHA} myapp:${DATE_TAG}
+      echo $DATE_TAG > image_tag.txt
+  rules:
+    - if: '$CI_COMMIT_REF_NAME == "release"'
+    - if: '$CI_COMMIT_TAG && $CI_COMMIT_TAG =~ /^v/'
+  needs:
+    - terraform_apply
+  artifacts:
+    paths:
+      - image_tag.txt
+
+push_image:
+  stage: deploy
+  image: docker:24
+  before_script:
+    - apk add --no-cache python3 py3-pip
+    - pip install awscli
+    - aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $AWS_ECR_ACCOUNT_URL
+  script:
+    - DATE_TAG=$(cat image_tag.txt)
+    - docker tag myapp:${DATE_TAG} $AWS_ECR_ACCOUNT_URL/myapp:${DATE_TAG}
+    - docker push $AWS_ECR_ACCOUNT_URL/myapp:${DATE_TAG}
+  rules:
+    - if: '$CI_COMMIT_REF_NAME == "release"'
+    - if: '$CI_COMMIT_TAG && $CI_COMMIT_TAG =~ /^v/'
+  needs:
+    - build_image
+  # AWS credentials are supplied via protected variables
+
+deploy_frontend:
+  stage: deploy
+  image: amazon/aws-cli:latest
+  dependencies:
+    - frontend_build
+  needs:
+    - frontend_build
+  script:
+    - aws s3 sync frontend/dist s3://$S3_BUCKET_NAME --delete
+  rules:
+    - if: '$CI_COMMIT_REF_NAME == "release"'
+  variables:
+    AWS_REGION: $AWS_DEFAULT_REGION

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,150 @@
+# AGENTS Guidelines
+
+このリポジトリで作業する際の開発ルールをまとめています。プルリクエストを作成する前に必ず確認してください。
+
+## 1. コーディングスタイル
+
+### フォーマッタ設定
+- **Python**: `black==23.7.0` を使用し、`--target-version py312 --line-length 100` で実行します。CI では `black --check` を必須とします。
+- **JavaScript/TypeScript**: `prettier@3.0.0` を利用し、`src/**/*.{ts,js,vue}` を対象に `prettier --write` を実行します。
+
+### インデント/改行
+- Python: 4 スペースインデント。
+- Vue/JS/TS: 2 スペースインデント。
+- 1 行あたりの最大文字数は 100 文字とし、超える場合は適切に改行します。
+
+### 命名規則
+- ファイル/ディレクトリは `snake_case` を基本とします。
+- クラス名は `PascalCase`、変数名・関数名は `snake_case` を使用します。
+- `Repository` `Service` などのサフィックスは用途を明確にするために付けてください。
+
+### 静的解析
+- `ruff==0.1.6` でコードスタイルを検査します。エラーは CI で失敗させます。
+- `mypy --strict` による型チェックを必須とします。
+
+### モノレポ差分
+- `packages/frontend` 配下のみ `.prettierrc` の設定を独自に許可します。
+
+## 2. テストと品質保証
+
+### テスト階層
+- 単体テスト: `pytest` を使用します。
+- 結合テスト: `docker-compose` で依存サービスを起動して実行します。
+- E2E テスト: `Playwright` を利用します。
+
+### 実行コマンド
+- 単体テスト: `pytest -q tests/`。
+- E2E テスト: `npm run test:e2e`。
+- docker compose の起動は `docker compose up -d`、終了は `docker compose down` を利用します。
+
+### カバレッジ閾値
+- `--cov=src --cov-fail-under=85` を指定し、85% 未満なら CI を失敗させます。
+
+### リトライ & キャッシュ
+- `pytest --reruns 2` で 2 回まで自動リトライします。
+- pip、npm のキャッシュを利用して CI 時間を短縮します。
+
+### セキュリティスキャン
+- `trivy fs --severity CRITICAL,HIGH .` を実行し、脆弱性が検出された場合は失敗させます。
+- `gitleaks detect` で機密情報の漏洩をチェックします。
+
+## 3. ビルド・デプロイ手順
+
+### ローカルビルド
+- `make build` でビルドします。Docker を利用する場合は `docker compose up --build` を実行します。
+
+### CI/CD ワークフロー
+- 本番環境: `deploy-prod`、検証環境: `deploy-staging`、プレビュー環境: `preview-env` のワークフローを用意します。
+
+### 環境変数管理
+- `.env*` ファイルは Git にコミットしないでください。必要に応じて `AWS Secrets Manager` や `GitHub Secrets` を利用します。
+- 秘密鍵は定期的にローテーションし、不要になったものは即座に削除してください。
+
+### プレースホルダ化の徹底
+環境やリソースの値は **決してハードコーディングせず**、下表のように GitLab CI/CD 変数や Docker `ARG` を使って参照してください。
+
+| 用途 | プレースホルダ | 補足 |
+| ---- | -------------- | ---- |
+| コンテナレジストリ | `${CI_REGISTRY}` / `${CI_REGISTRY_IMAGE}` | GitLab 提供のビルトイン変数 |
+| ECR URL | `${AWS_ECR_ACCOUNT_URL}` | リージョンやアカウントに応じて変化 |
+| AWS リージョン | `${AWS_REGION}` | 例: `ap-northeast-1` |
+| Docker イメージタグ | `${CI_COMMIT_SHA}` / `${CI_COMMIT_REF_SLUG}` | `latest` だけに依存しない |
+| CI 用カスタムイメージ | `${MY_CI_IMAGE}` | ビルド後に変数で指定 |
+| Django シークレット | `${DJANGO_SECRET_KEY}` | Protected & Masked を有効化 |
+| DB 接続情報 | `${DB_HOST}` `${DB_PORT}` `${DB_NAME}` `${DB_USER}` `${DB_PASSWORD}` | 環境ごとに切り替え |
+| AWS 認証情報 | `${AWS_ACCESS_KEY_ID}` `${AWS_SECRET_ACCESS_KEY}` | `terraform` や `aws-cli` 用 |
+| Terraform バックエンド | `${TF_STATE_BUCKET}` `${TF_STATE_KEY}` | S3 のバケット名とキー |
+| Terraform ワークスペース | `${TF_WORKSPACE}` | 例: `${CI_COMMIT_REF_SLUG}` |
+| Slack Webhook | `${SLACK_WEBHOOK_URL}` | 通知トークン |
+
+Dockerfile では次のように `ARG` を宣言し、CI から `--build-arg` で値を注入してください。
+
+```Dockerfile
+ARG TARGET_ENV=develop
+ARG MY_CI_IMAGE
+```
+
+.gitlab-ci.yml では以下のように変数を定義し、実際の値を外部から渡します。
+
+```yaml
+variables:
+  MY_CI_IMAGE: ${MY_CI_IMAGE}
+  AWS_REGION: ${AWS_REGION}
+  AWS_ECR_ACCOUNT_URL: ${AWS_ECR_ACCOUNT_URL}
+  DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY}
+  DB_HOST: ${DB_HOST}
+  DB_PORT: ${DB_PORT}
+  DB_NAME: ${DB_NAME}
+  DB_USER: ${DB_USER}
+  DB_PASSWORD: ${DB_PASSWORD}
+  AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+  AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+  TF_STATE_BUCKET: ${TF_STATE_BUCKET}
+  TF_STATE_KEY: ${TF_STATE_KEY}
+  TF_WORKSPACE: ${TF_WORKSPACE}
+  SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL}
+```
+
+上記変数は必ず GitLab の CI/CD 設定画面で登録し、`Protected` および `Masked` を適用してください。
+
+### アーティファクト管理
+- コンテナイメージタグは `myapp:{semver}-{gitsha}` の形式とします。
+- リリース物は 6 か月間保持し、署名付きで管理します。
+
+### ロールバック戦略
+- `argocd app rollback myapp <REVISION>` でロールバックを行います。
+
+## 4. ドキュメント更新ポリシー
+
+### 必須更新ファイル
+- 変更に伴い `README.md`、`docs/api/openapi.yaml`、`CHANGELOG.md` を更新してください。
+
+### 自動生成ドキュメント
+- `sphinx-build -b html docs docs/_build` を実行し、生成物の差分を PR に含めます。
+
+### ドキュメントカバレッジ
+- Python コードの docstring 充足率は 80% 以上を目指します。
+
+### ADR 追加基準
+- 複数システムに影響する変更、または戻すコストが 2 人日を超える場合は ADR を追加してください。
+
+### レビュー体制
+- `doc` ラベルが付いた PR は Tech Writer チームがレビューします。
+
+## 5. コミット・PR メッセージ規約
+
+### コミット規約
+- [Conventional Commits](https://www.conventionalcommits.org/) を採用します。例: `feat(auth): add OIDC login flow`。
+
+### PR テンプレート
+- 変更概要、試験結果、影響範囲、セキュリティ観点を PR 説明欄に記載してください。
+
+### 自動レビュアーアサイン
+- `CODEOWNERS` に基づき自動でレビュアーがアサインされます。`infrastructure/**` 変更時は `@infra-team` がレビュアーとなります。
+
+### ラベル & ブランチ戦略
+- ラベル: `feat`, `hotfix`, `infra` を使用します。
+- ブランチは trunk-based を基本とし、`feature/{jira-key}` や `release/v{semver}` と命名してください。
+
+### CI ブロッカー条件
+- `commitlint --config commitlint.config.js` でコミットメッセージを検査し、失敗した場合は CI を通過できません。

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,74 @@
+# syntax=docker/dockerfile:1.7
+# Multi-stage Dockerfile for Django application
+# Stage layout: deps -> build -> sast-node -> sast-python -> test -> runtime -> test-runtime
+
+ARG TARGET_ENV=develop
+ARG MY_CI_IMAGE
+ARG TFSEC_VERSION=1.28.1
+
+##### deps stage: build dependency wheels #####
+FROM python:3.12-slim AS deps
+WORKDIR /app
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gcc make curl \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+COPY requirements.txt ./
+RUN --mount=type=cache,target=/root/.cache/pip pip wheel -r requirements.txt --wheel-dir=/tmp/wheels \
+    && find /tmp/wheels -name '*.so' -exec strip --strip-unneeded {} + || true \
+    && apt-get purge -y gcc make curl && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+##### build stage: install uv and application code #####
+FROM python:3.12-slim AS build
+WORKDIR /app
+COPY --from=deps /tmp/wheels /tmp/wheels
+# Build stage installs application code
+COPY myproject ./myproject
+COPY manage.py ./
+
+##### Node.js SAST stage #####
+FROM node:18-bullseye-slim AS sast-node
+RUN --mount=type=cache,target=/root/.npm npm install -g eslint@8.56.0
+COPY --from=build /app /app
+
+##### Python SAST stage #####
+FROM python:3.12-slim AS sast-python
+ARG TFSEC_VERSION
+ARG TFSEC_SHA256
+RUN --mount=type=cache,target=/root/.cache/pip pip install --no-cache-dir ruff && \
+    ARCH=$(uname -m); \
+    case "$ARCH" in \
+      aarch64) TFSEC_BIN=tfsec-linux-arm64 ;; \
+      armv7l) TFSEC_BIN=tfsec-linux-armv7 ;; \
+      *) TFSEC_BIN=tfsec-linux-amd64 ;; \
+    esac && \
+    curl -sSL https://github.com/aquasecurity/tfsec/releases/download/v${TFSEC_VERSION}/${TFSEC_BIN} -o /usr/local/bin/tfsec && \
+    if [ -n "$TFSEC_SHA256" ]; then echo "$TFSEC_SHA256  /usr/local/bin/tfsec" | sha256sum -c -; fi && \
+    chmod +x /usr/local/bin/tfsec
+COPY --from=build /app /app
+
+##### test stage: pytest only #####
+FROM build AS test
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --no-cache-dir /tmp/wheels/* && \
+    pip install --no-cache-dir pytest
+
+##### runtime stage: minimal image #####
+FROM python:3.12-slim AS runtime
+ENV PYTHONUNBUFFERED=1 \
+    GUNICORN_TIMEOUT=120 \
+    GUNICORN_GRACEFUL_TIMEOUT=90
+WORKDIR /app
+COPY --from=deps /tmp/wheels /tmp/wheels
+RUN --mount=type=cache,target=/root/.cache/pip pip install /tmp/wheels/* && \
+    pip install --no-cache-dir uvicorn && \
+    rm -rf /tmp/wheels && apt-get clean && rm -rf /var/lib/apt/lists/*
+COPY myproject ./myproject
+COPY manage.py ./
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD []
+
+##### test runtime stage #####
+FROM runtime AS test-runtime
+RUN --mount=type=cache,target=/root/.cache/pip pip install --no-cache-dir pytest ruff

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # GPTs
+
+This repository contains sample infrastructure and CI/CD configuration.
+
+The `.dockerignore` excludes `.gitlab-ci.yml` so CI metadata does not become
+part of the Docker image. When building locally, run `docker buildx bake -f docker-bake.hcl`.
+See `AGENTS.md` for development standards.

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,50 @@
+group "all" {
+  targets = ["build", "sast-node", "sast-python", "test", "test-runtime", "runtime"]
+}
+
+target "common" {
+  context = "."
+  dockerfile = "Dockerfile"
+}
+
+target "build" {
+  inherits = ["common"]
+  target = "build"
+  cache-from = ["type=registry,ref=${CI_REGISTRY_IMAGE?err}/myapp-build:cache"]
+  cache-to = ["type=registry,ref=${CI_REGISTRY_IMAGE?err}/myapp-build:cache,mode=max,image-manifest=false"]
+}
+
+target "sast-node" {
+  inherits = ["common"]
+  target = "sast-node"
+  cache-from = ["type=registry,ref=${CI_REGISTRY_IMAGE?err}/myapp-sast-node:cache"]
+  cache-to = ["type=registry,ref=${CI_REGISTRY_IMAGE?err}/myapp-sast-node:cache,mode=max,image-manifest=false"]
+}
+
+target "sast-python" {
+  inherits = ["common"]
+  target = "sast-python"
+  cache-from = ["type=registry,ref=${CI_REGISTRY_IMAGE?err}/myapp-sast-python:cache"]
+  cache-to = ["type=registry,ref=${CI_REGISTRY_IMAGE?err}/myapp-sast-python:cache,mode=max,image-manifest=false"]
+}
+
+target "test" {
+  inherits = ["common"]
+  target = "test"
+  cache-from = ["type=registry,ref=${CI_REGISTRY_IMAGE?err}/myapp-test:cache"]
+  cache-to = ["type=registry,ref=${CI_REGISTRY_IMAGE?err}/myapp-test:cache,mode=max,image-manifest=false"]
+}
+
+target "test-runtime" {
+  inherits = ["common"]
+  target = "test-runtime"
+  cache-from = ["type=registry,ref=${CI_REGISTRY_IMAGE?err}/myapp-test-runtime:cache"]
+  cache-to = ["type=registry,ref=${CI_REGISTRY_IMAGE?err}/myapp-test-runtime:cache,mode=max,image-manifest=false"]
+}
+
+target "runtime" {
+  inherits = ["common"]
+  target = "runtime"
+  cache-from = ["type=registry,ref=${CI_REGISTRY_IMAGE?err}/myapp-runtime:cache"]
+  cache-to = ["type=registry,ref=${CI_REGISTRY_IMAGE?err}/myapp-runtime:cache,mode=max,image-manifest=false"]
+}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -euo pipefail
+trap 'echo "SIGTERM received, forwarding to Gunicorn"; kill -TERM "$child" 2>/dev/null' INT TERM
+exec gunicorn myproject.asgi:application -k uvicorn.workers.UvicornWorker \
+  --bind 0.0.0.0:8000 \
+  --graceful-timeout ${GUNICORN_GRACEFUL_TIMEOUT:-90} \
+  --timeout ${GUNICORN_TIMEOUT:-120} "$@" &
+child=$!
+wait "$child"


### PR DESCRIPTION
## Summary
- switch pipeline to use a custom CI image and enable Docker-in-Docker service globally
- expose build arguments in Dockerfile for environment specific builds

## Testing
- `black --check --target-version py312 --line-length 100 .`
- `ruff check .`
- `mypy .`
- `yamllint -d '{extends: default, rules: {line-length: disable}}' .gitlab-ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_68467cd2cf20832bac6131d37973e0f4