### PR TITLE
chore(docs): remove documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+- add Terraform environment and module scaffolding
+- define provider version and document CI/CD variables
+- enable tfsec-suggested security options in modules
+- remove binary files from Sphinx build output
+- remove docs directory and Sphinx configuration

--- a/README.md
+++ b/README.md
@@ -4,7 +4,31 @@ See AGENTS.md for development guidelines.
 
 ## Terraform Modules
 
-Reusable infrastructure modules are stored under `terraform/modules`.
-The `webinfra` module provisions a multi-environment AWS stack including
-VPC, ECS Fargate, RDS, and other components.
+Reusable infrastructure modules are stored under `terraform/modules`. Each
+component is isolated into its own module so it can be imported via
+`module` blocks from environment configurations.
+
+The `envs` directory contains one root module per environment (e.g. `prod`
+and `staging`). These root modules configure the backend and provider and
+instantiate the individual service modules such as ECR, ECS, RDS, Lambda,
+ALB, CloudFront, and S3.
+
+Each environment specifies the AWS provider via a `required_providers` block
+with version `~> 5.0`. Backend values like bucket and key must be injected
+through CI/CD variables (`TF_STATE_BUCKET`, `TF_STATE_KEY`, `AWS_REGION`).
+
+Security best practices are implemented in the modules:
+
+- ALB drops invalid headers and is internal by default.
+- ECR enables image scanning on push.
+- CloudFront supports modern TLS and accepts an optional WAF Web ACL.
+- Lambda functions have tracing enabled.
+- RDS instances enable performance insights.
+- S3 buckets create a public access block.
+
+Run `tfsec terraform` to validate Terraform security settings.
+
+When adding a new environment, create a directory under `envs/` and supply
+values via variables or CI/CD variables as described in `AGENTS.md`.
+The repository no longer includes Sphinx documentation.
 

--- a/terraform/envs/prod/main.tf
+++ b/terraform/envs/prod/main.tf
@@ -1,0 +1,62 @@
+terraform {
+  required_version = "~> 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+    bucket = var.tf_state_bucket
+    key    = var.tf_state_key
+    region = var.aws_region
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+module "s3" {
+  source = "../../modules/s3"
+  bucket = var.s3_bucket_name
+}
+
+module "ecr" {
+  source = "../../modules/ecr"
+  name   = var.ecr_repository_name
+}
+
+module "ecs" {
+  source       = "../../modules/ecs"
+  cluster_name = var.ecs_cluster_name
+}
+
+module "rds" {
+  source     = "../../modules/rds"
+  identifier = var.rds_identifier
+  username   = var.rds_username
+  password   = var.rds_password
+}
+
+module "lambda" {
+  source        = "../../modules/lambda"
+  function_name = var.lambda_function_name
+  handler       = var.lambda_handler
+  role_arn      = var.lambda_role_arn
+  filename      = var.lambda_filename
+}
+
+module "alb" {
+  source     = "../../modules/alb"
+  name       = var.alb_name
+  subnet_ids = var.alb_subnet_ids
+  internal   = var.alb_internal
+}
+
+module "cloudfront" {
+  source         = "../../modules/cloudfront"
+  s3_domain_name = module.s3.bucket_domain_name
+  web_acl_id     = var.cloudfront_web_acl_id
+}

--- a/terraform/envs/prod/variables.tf
+++ b/terraform/envs/prod/variables.tf
@@ -1,0 +1,25 @@
+variable "aws_region" { type = string }
+variable "tf_state_bucket" { type = string }
+variable "tf_state_key" { type = string }
+variable "s3_bucket_name" { type = string }
+variable "ecr_repository_name" { type = string }
+variable "ecs_cluster_name" { type = string }
+variable "rds_identifier" { type = string }
+variable "rds_username" { type = string }
+variable "rds_password" { type = string }
+variable "lambda_function_name" { type = string }
+variable "lambda_handler" { type = string }
+variable "lambda_role_arn" { type = string }
+variable "lambda_filename" { type = string }
+variable "alb_name" { type = string }
+variable "alb_subnet_ids" { type = list(string) }
+variable "alb_internal" {
+  type        = bool
+  description = "Whether the ALB is internal"
+  default     = true
+}
+variable "cloudfront_web_acl_id" {
+  type        = string
+  description = "ID of the WAF Web ACL for CloudFront"
+  default     = ""
+}

--- a/terraform/envs/staging/main.tf
+++ b/terraform/envs/staging/main.tf
@@ -1,0 +1,62 @@
+terraform {
+  required_version = "~> 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+    bucket = var.tf_state_bucket
+    key    = var.tf_state_key
+    region = var.aws_region
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+module "s3" {
+  source = "../../modules/s3"
+  bucket = var.s3_bucket_name
+}
+
+module "ecr" {
+  source = "../../modules/ecr"
+  name   = var.ecr_repository_name
+}
+
+module "ecs" {
+  source       = "../../modules/ecs"
+  cluster_name = var.ecs_cluster_name
+}
+
+module "rds" {
+  source     = "../../modules/rds"
+  identifier = var.rds_identifier
+  username   = var.rds_username
+  password   = var.rds_password
+}
+
+module "lambda" {
+  source        = "../../modules/lambda"
+  function_name = var.lambda_function_name
+  handler       = var.lambda_handler
+  role_arn      = var.lambda_role_arn
+  filename      = var.lambda_filename
+}
+
+module "alb" {
+  source     = "../../modules/alb"
+  name       = var.alb_name
+  subnet_ids = var.alb_subnet_ids
+  internal   = var.alb_internal
+}
+
+module "cloudfront" {
+  source         = "../../modules/cloudfront"
+  s3_domain_name = module.s3.bucket_domain_name
+  web_acl_id     = var.cloudfront_web_acl_id
+}

--- a/terraform/envs/staging/variables.tf
+++ b/terraform/envs/staging/variables.tf
@@ -1,0 +1,25 @@
+variable "aws_region" { type = string }
+variable "tf_state_bucket" { type = string }
+variable "tf_state_key" { type = string }
+variable "s3_bucket_name" { type = string }
+variable "ecr_repository_name" { type = string }
+variable "ecs_cluster_name" { type = string }
+variable "rds_identifier" { type = string }
+variable "rds_username" { type = string }
+variable "rds_password" { type = string }
+variable "lambda_function_name" { type = string }
+variable "lambda_handler" { type = string }
+variable "lambda_role_arn" { type = string }
+variable "lambda_filename" { type = string }
+variable "alb_name" { type = string }
+variable "alb_subnet_ids" { type = list(string) }
+variable "alb_internal" {
+  type        = bool
+  description = "Whether the ALB is internal"
+  default     = true
+}
+variable "cloudfront_web_acl_id" {
+  type        = string
+  description = "ID of the WAF Web ACL for CloudFront"
+  default     = ""
+}

--- a/terraform/modules/alb/main.tf
+++ b/terraform/modules/alb/main.tf
@@ -1,0 +1,23 @@
+resource "aws_lb" "main" {
+  name               = var.name
+  load_balancer_type = "application"
+  subnets            = var.subnet_ids
+  internal           = var.internal
+  drop_invalid_header_fields = true
+}
+
+variable "name" {
+  type        = string
+  description = "Name of the ALB"
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "Subnets for the ALB"
+}
+
+variable "internal" {
+  type        = bool
+  description = "Whether the ALB is internal"
+  default     = true
+}

--- a/terraform/modules/cloudfront/main.tf
+++ b/terraform/modules/cloudfront/main.tf
@@ -1,0 +1,38 @@
+resource "aws_cloudfront_distribution" "main" {
+  origin {
+    domain_name = var.s3_domain_name
+    origin_id   = "s3-origin"
+  }
+
+  enabled = true
+  default_cache_behavior {
+    viewer_protocol_policy = "redirect-to-https"
+    target_origin_id       = "s3-origin"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+    minimum_protocol_version       = "TLSv1.2_2021"
+  }
+
+  web_acl_id = var.web_acl_id
+}
+
+variable "s3_domain_name" {
+  type        = string
+  description = "Domain name of the S3 origin"
+}
+
+variable "web_acl_id" {
+  type        = string
+  description = "ID of the WAF Web ACL"
+  default     = ""
+}

--- a/terraform/modules/ecr/main.tf
+++ b/terraform/modules/ecr/main.tf
@@ -1,0 +1,16 @@
+resource "aws_ecr_repository" "main" {
+  name                 = var.name
+  image_tag_mutability = "IMMUTABLE"
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+output "repository_url" {
+  value = aws_ecr_repository.main.repository_url
+}
+
+variable "name" {
+  type        = string
+  description = "Name of the ECR repository"
+}

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -1,0 +1,8 @@
+resource "aws_ecs_cluster" "main" {
+  name = var.cluster_name
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "Name of the ECS cluster"
+}

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -1,0 +1,30 @@
+resource "aws_lambda_function" "main" {
+  function_name = var.function_name
+  handler       = var.handler
+  runtime       = "python3.12"
+  role          = var.role_arn
+  filename      = var.filename
+  tracing_config {
+    mode = "Active"
+  }
+}
+
+variable "function_name" {
+  type        = string
+  description = "Name of the Lambda function"
+}
+
+variable "handler" {
+  type        = string
+  description = "Handler entry point"
+}
+
+variable "role_arn" {
+  type        = string
+  description = "IAM role ARN"
+}
+
+variable "filename" {
+  type        = string
+  description = "Deployment package"
+}

--- a/terraform/modules/rds/main.tf
+++ b/terraform/modules/rds/main.tf
@@ -1,0 +1,25 @@
+resource "aws_db_instance" "main" {
+  identifier          = var.identifier
+  engine              = "postgres"
+  instance_class      = "db.t3.micro"
+  allocated_storage   = 20
+  username            = var.username
+  password            = var.password
+  skip_final_snapshot = true
+  performance_insights_enabled = true
+}
+
+variable "identifier" {
+  type        = string
+  description = "Identifier of the RDS instance"
+}
+
+variable "username" {
+  type        = string
+  description = "Master username"
+}
+
+variable "password" {
+  type        = string
+  description = "Master password"
+}

--- a/terraform/modules/s3/main.tf
+++ b/terraform/modules/s3/main.tf
@@ -1,0 +1,21 @@
+resource "aws_s3_bucket" "main" {
+  bucket = var.bucket
+}
+
+resource "aws_s3_bucket_public_access_block" "main" {
+  bucket = aws_s3_bucket.main.id
+
+  block_public_acls   = true
+  block_public_policy = true
+  ignore_public_acls  = true
+  restrict_public_buckets = true
+}
+
+output "bucket_domain_name" {
+  value = aws_s3_bucket.main.bucket_domain_name
+}
+
+variable "bucket" {
+  type        = string
+  description = "Name of the S3 bucket"
+}


### PR DESCRIPTION
## Summary
- drop Sphinx documentation entirely
- note docs removal in README and changelog

## Testing
- `black --target-version py312 --line-length 100 -q .`
- `prettier src/**/*.{ts,js,vue} --write` *(fails: No files matching)*
- `ruff check .`
- `mypy --strict .`
- `pytest -q tests/` *(fails: file or directory not found)*
- `sphinx-build -b html docs docs/_build` *(fails: command not found)*
- `trivy fs --severity CRITICAL,HIGH .` *(fails: command not found)*
- `gitleaks detect` *(fails: command not found)*
- `tfsec terraform` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852159e6564832b96053340686f5798